### PR TITLE
Implement support for Median function as a more robust alternative to mean

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1901,6 +1901,7 @@ type Matrix interface {
 func (df DataFrame) Describe() DataFrame {
 	labels := series.Strings([]string{
 		"mean",
+		"median",
 		"stddev",
 		"min",
 		"25%",
@@ -1919,6 +1920,7 @@ func (df DataFrame) Describe() DataFrame {
 			newCol = series.New([]string{
 				"-",
 				"-",
+				"-",
 				col.MinStr(),
 				"-",
 				"-",
@@ -1935,6 +1937,7 @@ func (df DataFrame) Describe() DataFrame {
 		case series.Int:
 			newCol = series.New([]float64{
 				col.Mean(),
+				col.Median(),
 				col.StdDev(),
 				col.Min(),
 				col.Quantile(0.25),

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -2501,27 +2501,27 @@ func TestDescribe(t *testing.T) {
 
 			New(
 				series.New(
-					[]string{"mean", "stddev", "min", "25%", "50%", "75%", "max"},
+					[]string{"mean", "median", "stddev", "min", "25%", "50%", "75%", "max"},
 					series.String,
 					"",
 				),
 				series.New(
-					[]string{"-", "-", "a", "-", "-", "-", "c"},
+					[]string{"-", "-", "-", "a", "-", "-", "-", "c"},
 					series.String,
 					"A",
 				),
 				series.New(
-					[]float64{3.25, 0.957427, 2.0, 2.0, 3.0, 4.0, 4.0},
+					[]float64{3.25, 3.5, 0.957427, 2.0, 2.0, 3.0, 4.0, 4.0},
 					series.Float,
 					"B",
 				),
 				series.New(
-					[]float64{6.05, 0.818535, 5.1, 5.1, 6.0, 6.0, 7.1},
+					[]float64{6.05, 6., 0.818535, 5.1, 5.1, 6.0, 6.0, 7.1},
 					series.Float,
 					"C",
 				),
 				series.New(
-					[]float64{0.5, 0.57735, 0.0, 0.0, 0.0, 1.0, 1.0},
+					[]float64{0.5, math.NaN(), 0.57735, 0.0, 0.0, 0.0, 1.0, 1.0},
 					series.Float,
 					"D",
 				),

--- a/series/series.go
+++ b/series/series.go
@@ -664,6 +664,32 @@ func (s Series) Mean() float64 {
 	return stdDev
 }
 
+// Median calculates the middle or median value, as opposed to
+// mean, and there is less susceptible to being affected by outliers.
+func (s Series) Median() float64 {
+	if s.elements.Len() == 0 ||
+		s.Type() == String ||
+		s.Type() == Bool {
+		return math.NaN()
+	}
+	ix := s.Order(false)
+	newElem := make([]Element, len(ix))
+
+	for newpos, oldpos := range ix {
+		newElem[newpos] = s.elements.Elem(oldpos)
+	}
+
+	// When length is odd, we just take length(list)/2
+	// value as the median.
+	if len(newElem)%2 != 0 {
+		return newElem[len(newElem)/2].Float()
+	}
+	// When length is even, we take middle two elements of
+	// list and the median is an average of the two of them.
+	return (newElem[(len(newElem)/2)-1].Float() +
+		newElem[len(newElem)/2].Float()) * 0.5
+}
+
 // Max return the biggest element in the series
 func (s Series) Max() float64 {
 	if s.elements.Len() == 0 || s.Type() == String {

--- a/series/series_test.go
+++ b/series/series_test.go
@@ -1295,6 +1295,60 @@ func TestSeries_Max(t *testing.T) {
 	}
 }
 
+func TestSeries_Median(t *testing.T) {
+	tests := []struct {
+		series   Series
+		expected float64
+	}{
+		{
+			// Extreme observations should not factor in.
+			Ints([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000, 10000}),
+			7,
+		},
+		{
+			// Change in order should influence result.
+			Ints([]int{1, 2, 3, 10, 100, 1000, 10000, 4, 5, 6, 7, 8, 9}),
+			7,
+		},
+		{
+			Floats([]float64{20.2755, 4.98964, -20.2006, 1.19854, 1.89977,
+				1.51178, -17.4687, 4.65567, -8.65952, 6.31649,
+			}),
+			1.705775,
+		},
+		{
+			// Change in order should not influence result.
+			Floats([]float64{4.98964, -20.2006, 1.89977, 1.19854,
+				1.51178, -17.4687, -8.65952, 20.2755, 4.65567, 6.31649,
+			}),
+			1.705775,
+		},
+		{
+			Strings([]string{"A", "B", "C", "D"}),
+			math.NaN(),
+		},
+		{
+			Bools([]bool{true, true, false, true}),
+			math.NaN(),
+		},
+		{
+			Floats([]float64{}),
+			math.NaN(),
+		},
+	}
+
+	for testnum, test := range tests {
+		received := test.series.Median()
+		expected := test.expected
+		if !compareFloats(received, expected, 6) {
+			t.Errorf(
+				"Test:%v\nExpected:\n%v\nReceived:\n%v",
+				testnum, expected, received,
+			)
+		}
+	}
+}
+
 func TestSeries_Min(t *testing.T) {
 	tests := []struct {
 		series   Series


### PR DESCRIPTION
Hopefully you will find this useful. I feel like having median and mean together is quite valuable, in particular to make comparisons from same data. Certainly wide divergence between the two implies data has outliers. If you would rather change this implementation but do find it useful, do let me know.

Thanks!