### PR TITLE
changed from deprecated stats

### DIFF
--- a/series/series.go
+++ b/series/series.go
@@ -8,7 +8,7 @@ import (
 
 	"math"
 
-	"github.com/gonum/stat"
+	"gonum.org/v1/gonum/stat"
 )
 
 // Series is a data structure designed for operating on arrays of elements that


### PR DESCRIPTION
https://github.com/gonum/stat is deprecated. It is now recommend to install gonum like this: `go get -u -t gonum.org/v1/gonum/...`