### PR TITLE
Updating gonum/stat import path.

### DIFF
--- a/series/series.go
+++ b/series/series.go
@@ -8,7 +8,7 @@ import (
 
 	"math"
 
-	"github.com/gonum/stat"
+	"gonum.org/v1/gonum/stat"
 )
 
 // Series is a data structure designed for operating on arrays of elements that


### PR DESCRIPTION
Import path"github.com/gonum/stat" seems to be obsolete.
Replacing it with "gonum.org/v1/gonum/stat".